### PR TITLE
Toggle an event on light toggle

### DIFF
--- a/Data Files/MWSE/mods/mer/midnightOil/common.lua
+++ b/Data Files/MWSE/mods/mer/midnightOil/common.lua
@@ -267,6 +267,11 @@ function this.removeLight(ref)
     ref.sceneNode:updateNodeEffects()
     ref.data.lightTurnedOff = true
     ref.modified = true
+
+    ---@class MidnightOil.lightOnOffEventData
+    ---@field reference tes3reference The light that was toggled on/off
+
+    event.trigger("Midnight Oil: light off", { reference = ref })
 end
 
 ---Turns the light back on by creating a new
@@ -308,6 +313,8 @@ function this.onLight(lightRef)
     end
     newRef.modified = true
     lightRef:delete()
+
+    event.trigger("Midnight Oil: light on", { reference = newRef })
 end
 
 return this


### PR DESCRIPTION
This PR makes it so that an event is fired whenever Midnight Oil turns a light on/off. This is something I'd need to implement compatibility in my [Candle Smoke](https://www.nexusmods.com/morrowind/mods/55671) mod. I need the `off` event to kill the smoke effect, and `on` to reapply the smoke effect. 


A usage example (from Candle Smoke):
```lua

---@param e MidnightOil.lightOnOffEventData
local function onToggleOn(e)
	effectManager:applyCandleSmokeEffect(e.reference, true)
end
event.register("Midnight Oil: light on", onToggleOn)

---@param e referenceDeactivatedEventData|activateEventData|MidnightOil.lightOnOffEventData
local function removeSmoke(e)
	local reference = e.reference or e.target
	effectManager:detachSmokeEffect(reference, true)
end
-- Remove smoke effect if a candle is picked up.
event.register(tes3.event.activate, removeSmoke, { priority = -2000 })
-- Some safety cleanup
event.register(tes3.event.referenceDeactivated, removeSmoke)
event.register("Midnight Oil: light off", removeSmoke)

```